### PR TITLE
ImagePicker returning same image

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -396,13 +396,16 @@ static NSString* toBase64(NSData* data) {
     NSString* docsPath = [NSTemporaryDirectory()stringByStandardizingPath];
     NSFileManager* fileMgr = [[NSFileManager alloc] init]; // recommended by Apple (vs [NSFileManager defaultManager]) to be threadsafe
     NSString* filePath;
-
+    
     // generate unique file name
-    int i = 1;
+    //int i = 1; 
+	NSTimeInterval timeStamp = [[NSDate date] timeIntervalSince1970];
+	// NSTimeInterval is defined as double
+	NSNumber *timeStampObj = [NSNumber numberWithDouble: timeStamp];
     do {
-        filePath = [NSString stringWithFormat:@"%@/%@%03d.%@", docsPath, CDV_PHOTO_PREFIX, i++, extension];
+        filePath = [NSString stringWithFormat:@"%@/%@%ld.%@", docsPath, CDV_PHOTO_PREFIX, [timeStampObj longValue], extension];
     } while ([fileMgr fileExistsAtPath:filePath]);
-
+    
     return filePath;
 }
 


### PR DESCRIPTION
iOS 10.2+ web view keep returning same image regardless whichever we pick from gallery view, given if we use FILE_URI method. I was looking for a solution of this issue, and while most suggestion was to use DATA_URI instead of FILE_URI that increases memory usage (at least in my case). After putting some breakpoint and debugging here is what I found: 

- Cordova app code request camera to pick a image from gallery with FILE_URI destination
- CDVCamera.m contains code which execute that native task and store file at a `temporary` location and return its URI. 
- In order to get the temporary file name, `tempFilePath` method is used, which sets an integer value of 1 and then loop through temporary directory until it find an unused name with incrementing that value. 
- Cordova app consume the URI and read data. 
- As a best practice it calls `cleanup()` for freeing temporary resource. 
- CDVCamera.m removes the temporary file. 

This all flow works fine. However next time in same session when client request another picture, tempFilePath method returns same filename because there is no previous file holding the name. That is also fine, but here the twist by web view, which getting same URL returns old image (from browser's cache). Experimenting with filename gives a fix that if we use a random filename, it works as expected. 

So I propose this change (which should work almost in all cases, as picking a image from gallery will take in general more than 1 second), which uses unix timestamp value instead of  integer ` i`. 

I don't have coding experience with Objective-C, so code change between line #402-404 can be updated to use better approach instead of 3 objects (date, interval and number).

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
